### PR TITLE
staticsfiles not registered

### DIFF
--- a/web/viperweb/templates/rest_framework_swagger/index.html
+++ b/web/viperweb/templates/rest_framework_swagger/index.html
@@ -1,6 +1,6 @@
 {% extends "rest_framework_swagger/base.html" %}
 
 {% block extra_styles %}
-  {% load static from staticfiles %}
+  {% load static from statics %}
   <link rel="stylesheet" href="{% static "swagger-ui-themes/css/theme-feeling-blue.css" %}">
 {% endblock %}


### PR DESCRIPTION
django.template.exceptions.TemplateSyntaxError: 'staticfiles' is not a registered tag library. Must be one of: